### PR TITLE
Refactor/puppeteer core fix dec11

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -5,20 +5,14 @@
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-    webpack: (config, { isServer }) => {
+    experimental: {
+        serverComponentsExternalPackages: ["puppeteer-core"],
+    },
+    webpack: (config) => {
         config.module.rules.push({
             test: /\.map$/,
             use: "ignore-loader",
         });
-
-        if (!isServer) {
-            config.externals = {
-                ...config.externals,
-                "puppeteer-core": "commonjs puppeteer-core",
-                "@sparticuz/chromium": "commonjs @sparticuz/chromium",
-            };
-        }
-
         return config;
     },
 };

--- a/next.config.js
+++ b/next.config.js
@@ -5,11 +5,19 @@
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-    webpack: (config) => {
+    webpack: (config, { isServer }) => {
         config.module.rules.push({
             test: /\.map$/,
             use: "ignore-loader",
         });
+
+        if (!isServer) {
+            config.externals = {
+                ...config.externals,
+                "puppeteer-core": "commonjs puppeteer-core",
+                "@sparticuz/chromium": "commonjs @sparticuz/chromium",
+            };
+        }
 
         return config;
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
                 "@react-email/components": "^0.0.11",
                 "@react-email/render": "^0.0.9",
                 "@react-email/tailwind": "^0.0.12",
+                "@sparticuz/chromium": "^119.0.0",
                 "@types/node": "20.6.2",
                 "@vercel/analytics": "^1.1.1",
                 "autoprefixer": "10.4.15",
@@ -43,7 +44,6 @@
                 "nodemailer": "^6.9.7",
                 "number-to-words": "^1.2.4",
                 "postcss": "8.4.31",
-                "puppeteer": "^21.3.1",
                 "puppeteer-core": "^21.5.0",
                 "react": "18.2.0",
                 "react-day-picker": "^8.8.2",
@@ -63,14 +63,14 @@
                 "zod": "^3.22.2"
             },
             "devDependencies": {
-                "@sparticuz/chromium": "^119.0.0",
                 "@types/nodemailer": "^6.4.14",
                 "@types/number-to-words": "^1.2.1",
                 "@types/react": "^18.2.22",
                 "@types/react-dom": "^18.2.7",
                 "@types/react-signature-canvas": "^1.0.4",
                 "@types/xml2js": "^0.4.13",
-                "ignore-loader": "^0.1.2"
+                "ignore-loader": "^0.1.2",
+                "puppeteer": "^21.3.1"
             }
         },
         "node_modules/@alloc/quick-lru": {
@@ -1603,6 +1603,7 @@
             "version": "1.7.1",
             "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-1.7.1.tgz",
             "integrity": "sha512-nIb8SOBgDEMFY2iS2MdnUZOg2ikcYchRrBoF+wtdjieRFKR2uGRipHY/oFLo+2N6anDualyClPzGywTHRGrLfw==",
+            "dev": true,
             "dependencies": {
                 "debug": "4.3.4",
                 "extract-zip": "2.0.1",
@@ -3088,7 +3089,6 @@
             "version": "119.0.0",
             "resolved": "https://registry.npmjs.org/@sparticuz/chromium/-/chromium-119.0.0.tgz",
             "integrity": "sha512-wwc3E552woNUMBVDM57YGvxBTqpSSjtjeybZIgILsxAeqMKnQw0WYY6Aiy9NzUs2Dtf5Q6LS4emfDtTxntl4xA==",
-            "dev": true,
             "dependencies": {
                 "follow-redirects": "^1.15.3",
                 "tar-fs": "^3.0.4"
@@ -3282,7 +3282,8 @@
         "node_modules/argparse": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-            "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
+            "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+            "dev": true
         },
         "node_modules/aria-hidden": {
             "version": "1.2.3",
@@ -3520,6 +3521,7 @@
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
             "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+            "dev": true,
             "engines": {
                 "node": ">=6"
             }
@@ -3641,6 +3643,7 @@
             "version": "0.4.27",
             "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-0.4.27.tgz",
             "integrity": "sha512-8Irq0FbKYN8Xmj8M62kta6wk5MyDKeYIFtNavxQ2M3xf2v5MCC4ntf+FxitQu1iHaQvGU6t5O+Nrep0RNNS0EQ==",
+            "dev": true,
             "dependencies": {
                 "mitt": "3.0.1",
                 "urlpattern-polyfill": "9.0.0"
@@ -3821,6 +3824,7 @@
             "version": "8.3.6",
             "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-8.3.6.tgz",
             "integrity": "sha512-kcZ6+W5QzcJ3P1Mt+83OUv/oHFqZHIx8DuxG6eZ5RGMERoLqp4BuGjhHLYGK+Kf5XVkQvqBSmAy/nGWN3qDgEA==",
+            "dev": true,
             "dependencies": {
                 "import-fresh": "^3.3.0",
                 "js-yaml": "^4.1.0",
@@ -4430,7 +4434,6 @@
             "version": "1.15.3",
             "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.3.tgz",
             "integrity": "sha512-1VzOtuEM8pC9SFU1E+8KfTjZyMztRsgEfwQl44z8A25uy13jSzTj6dyK2Df52iV0vgHCfBwLhDWevLn95w5v6Q==",
-            "dev": true,
             "funding": [
                 {
                     "type": "individual",
@@ -4787,6 +4790,7 @@
             "version": "3.3.0",
             "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
             "integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
+            "dev": true,
             "dependencies": {
                 "parent-module": "^1.0.0",
                 "resolve-from": "^4.0.0"
@@ -5131,6 +5135,7 @@
             "version": "4.1.0",
             "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
             "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+            "dev": true,
             "dependencies": {
                 "argparse": "^2.0.1"
             },
@@ -5849,6 +5854,7 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
             "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+            "dev": true,
             "dependencies": {
                 "callsites": "^3.0.0"
             },
@@ -6214,6 +6220,7 @@
             "version": "21.3.1",
             "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-21.3.1.tgz",
             "integrity": "sha512-MhDvA+BYmzx+9vHJ/ZtknhlPbSPjTlHQnW1QYfkGpBcGW2Yy6eMahjkNuhAzN29H9tb47IcT0QsVcUy3Txx+SA==",
+            "dev": true,
             "hasInstallScript": true,
             "dependencies": {
                 "@puppeteer/browsers": "1.7.1",
@@ -6292,12 +6299,14 @@
         "node_modules/puppeteer/node_modules/devtools-protocol": {
             "version": "0.0.1179426",
             "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1179426.tgz",
-            "integrity": "sha512-KKC7IGwdOr7u9kTGgjUvGTov/z1s2H7oHi3zKCdR9eSDyCPia5CBi4aRhtp7d8uR7l0GS5UTDw3TjKGu5CqINg=="
+            "integrity": "sha512-KKC7IGwdOr7u9kTGgjUvGTov/z1s2H7oHi3zKCdR9eSDyCPia5CBi4aRhtp7d8uR7l0GS5UTDw3TjKGu5CqINg==",
+            "dev": true
         },
         "node_modules/puppeteer/node_modules/puppeteer-core": {
             "version": "21.3.1",
             "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-21.3.1.tgz",
             "integrity": "sha512-3VrCDEAHk0hPvE8qtfKgsT8CzRuaQrDQGXdCOuMFJM7Ap+ghpQzhPa9H3DE3gZgwDvC5Jt7SxUkAWLCeNbD0xw==",
+            "dev": true,
             "dependencies": {
                 "@puppeteer/browsers": "1.7.1",
                 "chromium-bidi": "0.4.27",
@@ -6314,6 +6323,7 @@
             "version": "8.14.1",
             "resolved": "https://registry.npmjs.org/ws/-/ws-8.14.1.tgz",
             "integrity": "sha512-4OOseMUq8AzRBI/7SLMUwO+FEDnguetSk7KMb1sHwvF2w2Wv5Hoj0nlifx8vtGsftE/jWHojPy8sMMzYLJ2G/A==",
+            "dev": true,
             "engines": {
                 "node": ">=10.0.0"
             },
@@ -6814,6 +6824,7 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
             "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+            "dev": true,
             "engines": {
                 "node": ">=4"
             }
@@ -7967,6 +7978,7 @@
             "version": "17.7.1",
             "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.1.tgz",
             "integrity": "sha512-cwiTb08Xuv5fqF4AovYacTFNxk62th7LKJ6BL9IGUpTJrWoU7/7WdQGTP2SjKf1dUNBGzDd28p/Yfs/GI6JrLw==",
+            "dev": true,
             "dependencies": {
                 "cliui": "^8.0.1",
                 "escalade": "^3.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -44,7 +44,7 @@
                 "number-to-words": "^1.2.4",
                 "postcss": "8.4.31",
                 "puppeteer": "^21.3.1",
-                "puppeteer-core": "^19.8.0",
+                "puppeteer-core": "^21.5.0",
                 "react": "18.2.0",
                 "react-day-picker": "^8.8.2",
                 "react-dom": "18.2.0",
@@ -3637,11 +3637,6 @@
                 "node": ">= 6"
             }
         },
-        "node_modules/chownr": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
-            "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="
-        },
         "node_modules/chromium-bidi": {
             "version": "0.4.27",
             "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-0.4.27.tgz",
@@ -4030,8 +4025,7 @@
         "node_modules/devtools-protocol": {
             "version": "0.0.1203626",
             "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1203626.tgz",
-            "integrity": "sha512-nEzHZteIUZfGCZtTiS1fRpC8UZmsfD1SiyPvaUNvS13dvKf666OAm8YTi0+Ca3n1nLEyu49Cy4+dPWpaHFJk9g==",
-            "peer": true
+            "integrity": "sha512-nEzHZteIUZfGCZtTiS1fRpC8UZmsfD1SiyPvaUNvS13dvKf666OAm8YTi0+Ca3n1nLEyu49Cy4+dPWpaHFJk9g=="
         },
         "node_modules/didyoumean": {
             "version": "1.2.2",
@@ -4497,11 +4491,6 @@
                 "type": "patreon",
                 "url": "https://github.com/sponsors/rawify"
             }
-        },
-        "node_modules/fs-constants": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
-            "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="
         },
         "node_modules/fs-extra": {
             "version": "8.1.0",
@@ -6236,158 +6225,68 @@
             }
         },
         "node_modules/puppeteer-core": {
-            "version": "19.11.1",
-            "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-19.11.1.tgz",
-            "integrity": "sha512-qcuC2Uf0Fwdj9wNtaTZ2OvYRraXpAK+puwwVW8ofOhOgLPZyz1c68tsorfIZyCUOpyBisjr+xByu7BMbEYMepA==",
+            "version": "21.6.0",
+            "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-21.6.0.tgz",
+            "integrity": "sha512-1vrzbp2E1JpBwtIIrriWkN+A0afUxkqRuFTC3uASc5ql6iuK9ppOdIU/CPGKwOyB4YFIQ16mRbK0PK19mbXnaQ==",
             "dependencies": {
-                "@puppeteer/browsers": "0.5.0",
-                "chromium-bidi": "0.4.7",
-                "cross-fetch": "3.1.5",
+                "@puppeteer/browsers": "1.9.0",
+                "chromium-bidi": "0.5.1",
+                "cross-fetch": "4.0.0",
                 "debug": "4.3.4",
-                "devtools-protocol": "0.0.1107588",
-                "extract-zip": "2.0.1",
-                "https-proxy-agent": "5.0.1",
-                "proxy-from-env": "1.1.0",
-                "tar-fs": "2.1.1",
-                "unbzip2-stream": "1.4.3",
-                "ws": "8.13.0"
+                "devtools-protocol": "0.0.1203626",
+                "ws": "8.14.2"
             },
             "engines": {
-                "node": ">=14.14.0"
-            },
-            "peerDependencies": {
-                "typescript": ">= 4.7.4"
-            },
-            "peerDependenciesMeta": {
-                "typescript": {
-                    "optional": true
-                }
+                "node": ">=16.13.2"
             }
         },
         "node_modules/puppeteer-core/node_modules/@puppeteer/browsers": {
-            "version": "0.5.0",
-            "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-0.5.0.tgz",
-            "integrity": "sha512-Uw6oB7VvmPRLE4iKsjuOh8zgDabhNX67dzo8U/BB0f9527qx+4eeUs+korU98OhG5C4ubg7ufBgVi63XYwS6TQ==",
+            "version": "1.9.0",
+            "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-1.9.0.tgz",
+            "integrity": "sha512-QwguOLy44YBGC8vuPP2nmpX4MUN2FzWbsnvZJtiCzecU3lHmVZkaC1tq6rToi9a200m8RzlVtDyxCS0UIDrxUg==",
             "dependencies": {
                 "debug": "4.3.4",
                 "extract-zip": "2.0.1",
-                "https-proxy-agent": "5.0.1",
                 "progress": "2.0.3",
-                "proxy-from-env": "1.1.0",
-                "tar-fs": "2.1.1",
+                "proxy-agent": "6.3.1",
+                "tar-fs": "3.0.4",
                 "unbzip2-stream": "1.4.3",
-                "yargs": "17.7.1"
+                "yargs": "17.7.2"
             },
             "bin": {
                 "browsers": "lib/cjs/main-cli.js"
             },
             "engines": {
-                "node": ">=14.1.0"
-            },
-            "peerDependencies": {
-                "typescript": ">= 4.7.4"
-            },
-            "peerDependenciesMeta": {
-                "typescript": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/puppeteer-core/node_modules/agent-base": {
-            "version": "6.0.2",
-            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
-            "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
-            "dependencies": {
-                "debug": "4"
-            },
-            "engines": {
-                "node": ">= 6.0.0"
+                "node": ">=16.3.0"
             }
         },
         "node_modules/puppeteer-core/node_modules/chromium-bidi": {
-            "version": "0.4.7",
-            "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-0.4.7.tgz",
-            "integrity": "sha512-6+mJuFXwTMU6I3vYLs6IL8A1DyQTPjCfIL971X0aMPVGRbGnNfl6i6Cl0NMbxi2bRYLGESt9T2ZIMRM5PAEcIQ==",
+            "version": "0.5.1",
+            "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-0.5.1.tgz",
+            "integrity": "sha512-dcCqOgq9fHKExc2R4JZs/oKbOghWpUNFAJODS8WKRtLhp3avtIH5UDCBrutdqZdh3pARogH8y1ObXm87emwb3g==",
             "dependencies": {
-                "mitt": "3.0.0"
+                "mitt": "3.0.1",
+                "urlpattern-polyfill": "9.0.0"
             },
             "peerDependencies": {
                 "devtools-protocol": "*"
             }
         },
-        "node_modules/puppeteer-core/node_modules/cross-fetch": {
-            "version": "3.1.5",
-            "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.5.tgz",
-            "integrity": "sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==",
+        "node_modules/puppeteer-core/node_modules/yargs": {
+            "version": "17.7.2",
+            "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+            "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
             "dependencies": {
-                "node-fetch": "2.6.7"
-            }
-        },
-        "node_modules/puppeteer-core/node_modules/devtools-protocol": {
-            "version": "0.0.1107588",
-            "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1107588.tgz",
-            "integrity": "sha512-yIR+pG9x65Xko7bErCUSQaDLrO/P1p3JUzEk7JCU4DowPcGHkTGUGQapcfcLc4qj0UaALwZ+cr0riFgiqpixcg=="
-        },
-        "node_modules/puppeteer-core/node_modules/https-proxy-agent": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
-            "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
-            "dependencies": {
-                "agent-base": "6",
-                "debug": "4"
+                "cliui": "^8.0.1",
+                "escalade": "^3.1.1",
+                "get-caller-file": "^2.0.5",
+                "require-directory": "^2.1.1",
+                "string-width": "^4.2.3",
+                "y18n": "^5.0.5",
+                "yargs-parser": "^21.1.1"
             },
             "engines": {
-                "node": ">= 6"
-            }
-        },
-        "node_modules/puppeteer-core/node_modules/mitt": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.0.tgz",
-            "integrity": "sha512-7dX2/10ITVyqh4aOSVI9gdape+t9l2/8QxHrFmUXu4EEUpdlxl6RudZUPZoc+zuY2hk1j7XxVroIVIan/pD/SQ=="
-        },
-        "node_modules/puppeteer-core/node_modules/node-fetch": {
-            "version": "2.6.7",
-            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
-            "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
-            "dependencies": {
-                "whatwg-url": "^5.0.0"
-            },
-            "engines": {
-                "node": "4.x || >=6.0.0"
-            },
-            "peerDependencies": {
-                "encoding": "^0.1.0"
-            },
-            "peerDependenciesMeta": {
-                "encoding": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/puppeteer-core/node_modules/tar-fs": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.1.tgz",
-            "integrity": "sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==",
-            "dependencies": {
-                "chownr": "^1.1.1",
-                "mkdirp-classic": "^0.5.2",
-                "pump": "^3.0.0",
-                "tar-stream": "^2.1.4"
-            }
-        },
-        "node_modules/puppeteer-core/node_modules/tar-stream": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
-            "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
-            "dependencies": {
-                "bl": "^4.0.3",
-                "end-of-stream": "^1.4.1",
-                "fs-constants": "^1.0.0",
-                "inherits": "^2.0.3",
-                "readable-stream": "^3.1.1"
-            },
-            "engines": {
-                "node": ">=6"
+                "node": ">=12"
             }
         },
         "node_modules/puppeteer/node_modules/devtools-protocol": {
@@ -7984,9 +7883,9 @@
             "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
         },
         "node_modules/ws": {
-            "version": "8.13.0",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-8.13.0.tgz",
-            "integrity": "sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==",
+            "version": "8.14.2",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-8.14.2.tgz",
+            "integrity": "sha512-wEBG1ftX4jcglPxgFCMJmZ2PLtSbJ2Peg6TmpJFTbe9GZYOQCDPdMYu/Tm0/bGZkw8paZnJY45J4K2PZrLYq8g==",
             "engines": {
                 "node": ">=10.0.0"
             },

--- a/package-lock.json
+++ b/package-lock.json
@@ -44,7 +44,7 @@
                 "number-to-words": "^1.2.4",
                 "postcss": "8.4.31",
                 "puppeteer": "^21.3.1",
-                "puppeteer-core": "^10.4.0",
+                "puppeteer-core": "^19.8.0",
                 "react": "18.2.0",
                 "react-day-picker": "^8.8.2",
                 "react-dom": "18.2.0",
@@ -5426,14 +5426,6 @@
                 "node": "*"
             }
         },
-        "node_modules/minimist": {
-            "version": "1.2.8",
-            "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
-            "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
         "node_modules/minimist-options": {
             "version": "4.1.0",
             "resolved": "https://registry.npmjs.org/minimist-options/-/minimist-options-4.1.0.tgz",
@@ -5467,17 +5459,6 @@
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
             "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw=="
-        },
-        "node_modules/mkdirp": {
-            "version": "0.5.6",
-            "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
-            "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
-            "dependencies": {
-                "minimist": "^1.2.6"
-            },
-            "bin": {
-                "mkdirp": "bin/cmd.js"
-            }
         },
         "node_modules/mkdirp-classic": {
             "version": "0.5.3",
@@ -6020,17 +6001,6 @@
                 "node": ">= 6"
             }
         },
-        "node_modules/pkg-dir": {
-            "version": "4.2.0",
-            "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
-            "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
-            "dependencies": {
-                "find-up": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
         "node_modules/postcss": {
             "version": "8.4.31",
             "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
@@ -6266,25 +6236,61 @@
             }
         },
         "node_modules/puppeteer-core": {
-            "version": "10.4.0",
-            "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-10.4.0.tgz",
-            "integrity": "sha512-KU8zyb7AIOqNjLCN3wkrFXxh+EVaG+zrs2P03ATNjc3iwSxHsu5/EvZiREpQ/IJiT9xfQbDVgKcsvRuzLCxglQ==",
+            "version": "19.11.1",
+            "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-19.11.1.tgz",
+            "integrity": "sha512-qcuC2Uf0Fwdj9wNtaTZ2OvYRraXpAK+puwwVW8ofOhOgLPZyz1c68tsorfIZyCUOpyBisjr+xByu7BMbEYMepA==",
             "dependencies": {
-                "debug": "4.3.1",
-                "devtools-protocol": "0.0.901419",
+                "@puppeteer/browsers": "0.5.0",
+                "chromium-bidi": "0.4.7",
+                "cross-fetch": "3.1.5",
+                "debug": "4.3.4",
+                "devtools-protocol": "0.0.1107588",
                 "extract-zip": "2.0.1",
-                "https-proxy-agent": "5.0.0",
-                "node-fetch": "2.6.1",
-                "pkg-dir": "4.2.0",
-                "progress": "2.0.1",
+                "https-proxy-agent": "5.0.1",
                 "proxy-from-env": "1.1.0",
-                "rimraf": "3.0.2",
-                "tar-fs": "2.0.0",
-                "unbzip2-stream": "1.3.3",
-                "ws": "7.4.6"
+                "tar-fs": "2.1.1",
+                "unbzip2-stream": "1.4.3",
+                "ws": "8.13.0"
             },
             "engines": {
-                "node": ">=10.18.1"
+                "node": ">=14.14.0"
+            },
+            "peerDependencies": {
+                "typescript": ">= 4.7.4"
+            },
+            "peerDependenciesMeta": {
+                "typescript": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/puppeteer-core/node_modules/@puppeteer/browsers": {
+            "version": "0.5.0",
+            "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-0.5.0.tgz",
+            "integrity": "sha512-Uw6oB7VvmPRLE4iKsjuOh8zgDabhNX67dzo8U/BB0f9527qx+4eeUs+korU98OhG5C4ubg7ufBgVi63XYwS6TQ==",
+            "dependencies": {
+                "debug": "4.3.4",
+                "extract-zip": "2.0.1",
+                "https-proxy-agent": "5.0.1",
+                "progress": "2.0.3",
+                "proxy-from-env": "1.1.0",
+                "tar-fs": "2.1.1",
+                "unbzip2-stream": "1.4.3",
+                "yargs": "17.7.1"
+            },
+            "bin": {
+                "browsers": "lib/cjs/main-cli.js"
+            },
+            "engines": {
+                "node": ">=14.1.0"
+            },
+            "peerDependencies": {
+                "typescript": ">= 4.7.4"
+            },
+            "peerDependenciesMeta": {
+                "typescript": {
+                    "optional": true
+                }
             }
         },
         "node_modules/puppeteer-core/node_modules/agent-base": {
@@ -6298,31 +6304,34 @@
                 "node": ">= 6.0.0"
             }
         },
-        "node_modules/puppeteer-core/node_modules/debug": {
-            "version": "4.3.1",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
-            "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+        "node_modules/puppeteer-core/node_modules/chromium-bidi": {
+            "version": "0.4.7",
+            "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-0.4.7.tgz",
+            "integrity": "sha512-6+mJuFXwTMU6I3vYLs6IL8A1DyQTPjCfIL971X0aMPVGRbGnNfl6i6Cl0NMbxi2bRYLGESt9T2ZIMRM5PAEcIQ==",
             "dependencies": {
-                "ms": "2.1.2"
+                "mitt": "3.0.0"
             },
-            "engines": {
-                "node": ">=6.0"
-            },
-            "peerDependenciesMeta": {
-                "supports-color": {
-                    "optional": true
-                }
+            "peerDependencies": {
+                "devtools-protocol": "*"
+            }
+        },
+        "node_modules/puppeteer-core/node_modules/cross-fetch": {
+            "version": "3.1.5",
+            "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.5.tgz",
+            "integrity": "sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==",
+            "dependencies": {
+                "node-fetch": "2.6.7"
             }
         },
         "node_modules/puppeteer-core/node_modules/devtools-protocol": {
-            "version": "0.0.901419",
-            "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.901419.tgz",
-            "integrity": "sha512-4INMPwNm9XRpBukhNbF7OB6fNTTCaI8pzy/fXg0xQzAy5h3zL1P8xT3QazgKqBrb/hAYwIBizqDBZ7GtJE74QQ=="
+            "version": "0.0.1107588",
+            "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1107588.tgz",
+            "integrity": "sha512-yIR+pG9x65Xko7bErCUSQaDLrO/P1p3JUzEk7JCU4DowPcGHkTGUGQapcfcLc4qj0UaALwZ+cr0riFgiqpixcg=="
         },
         "node_modules/puppeteer-core/node_modules/https-proxy-agent": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
-            "integrity": "sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==",
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+            "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
             "dependencies": {
                 "agent-base": "6",
                 "debug": "4"
@@ -6331,31 +6340,39 @@
                 "node": ">= 6"
             }
         },
+        "node_modules/puppeteer-core/node_modules/mitt": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.0.tgz",
+            "integrity": "sha512-7dX2/10ITVyqh4aOSVI9gdape+t9l2/8QxHrFmUXu4EEUpdlxl6RudZUPZoc+zuY2hk1j7XxVroIVIan/pD/SQ=="
+        },
         "node_modules/puppeteer-core/node_modules/node-fetch": {
-            "version": "2.6.1",
-            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
-            "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==",
+            "version": "2.6.7",
+            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+            "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+            "dependencies": {
+                "whatwg-url": "^5.0.0"
+            },
             "engines": {
                 "node": "4.x || >=6.0.0"
-            }
-        },
-        "node_modules/puppeteer-core/node_modules/progress": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.1.tgz",
-            "integrity": "sha512-OE+a6vzqazc+K6LxJrX5UPyKFvGnL5CYmq2jFGNIBWHpc4QyE49/YOumcrpQFJpfejmvRtbJzgO1zPmMCqlbBg==",
-            "engines": {
-                "node": ">=0.4.0"
+            },
+            "peerDependencies": {
+                "encoding": "^0.1.0"
+            },
+            "peerDependenciesMeta": {
+                "encoding": {
+                    "optional": true
+                }
             }
         },
         "node_modules/puppeteer-core/node_modules/tar-fs": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.0.0.tgz",
-            "integrity": "sha512-vaY0obB6Om/fso8a8vakQBzwholQ7v5+uy+tF3Ozvxv1KNezmVQAiWtcNmMHFSFPqL3dJA8ha6gdtFbfX9mcxA==",
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.1.tgz",
+            "integrity": "sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==",
             "dependencies": {
                 "chownr": "^1.1.1",
-                "mkdirp": "^0.5.1",
+                "mkdirp-classic": "^0.5.2",
                 "pump": "^3.0.0",
-                "tar-stream": "^2.0.0"
+                "tar-stream": "^2.1.4"
             }
         },
         "node_modules/puppeteer-core/node_modules/tar-stream": {
@@ -6371,15 +6388,6 @@
             },
             "engines": {
                 "node": ">=6"
-            }
-        },
-        "node_modules/puppeteer-core/node_modules/unbzip2-stream": {
-            "version": "1.3.3",
-            "resolved": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.3.3.tgz",
-            "integrity": "sha512-fUlAF7U9Ah1Q6EieQ4x4zLNejrRvDWUYmxXUpN3uziFYCHapjWFaCAnreY9bGgxzaMCFAPPpYNng57CypwJVhg==",
-            "dependencies": {
-                "buffer": "^5.2.1",
-                "through": "^2.3.8"
             }
         },
         "node_modules/puppeteer/node_modules/devtools-protocol": {
@@ -6930,20 +6938,6 @@
             "engines": {
                 "iojs": ">=1.0.0",
                 "node": ">=0.10.0"
-            }
-        },
-        "node_modules/rimraf": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-            "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-            "dependencies": {
-                "glob": "^7.1.3"
-            },
-            "bin": {
-                "rimraf": "bin.js"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
             }
         },
         "node_modules/run-parallel": {
@@ -7990,15 +7984,15 @@
             "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
         },
         "node_modules/ws": {
-            "version": "7.4.6",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.6.tgz",
-            "integrity": "sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==",
+            "version": "8.13.0",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-8.13.0.tgz",
+            "integrity": "sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==",
             "engines": {
-                "node": ">=8.3.0"
+                "node": ">=10.0.0"
             },
             "peerDependencies": {
                 "bufferutil": "^4.0.1",
-                "utf-8-validate": "^5.0.2"
+                "utf-8-validate": ">=5.0.2"
             },
             "peerDependenciesMeta": {
                 "bufferutil": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -44,7 +44,7 @@
                 "number-to-words": "^1.2.4",
                 "postcss": "8.4.31",
                 "puppeteer": "^21.3.1",
-                "puppeteer-core": "^21.6.0",
+                "puppeteer-core": "^19.8.0",
                 "react": "18.2.0",
                 "react-day-picker": "^8.8.2",
                 "react-dom": "18.2.0",
@@ -3637,6 +3637,11 @@
                 "node": ">= 6"
             }
         },
+        "node_modules/chownr": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+            "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="
+        },
         "node_modules/chromium-bidi": {
             "version": "0.4.27",
             "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-0.4.27.tgz",
@@ -4025,7 +4030,8 @@
         "node_modules/devtools-protocol": {
             "version": "0.0.1203626",
             "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1203626.tgz",
-            "integrity": "sha512-nEzHZteIUZfGCZtTiS1fRpC8UZmsfD1SiyPvaUNvS13dvKf666OAm8YTi0+Ca3n1nLEyu49Cy4+dPWpaHFJk9g=="
+            "integrity": "sha512-nEzHZteIUZfGCZtTiS1fRpC8UZmsfD1SiyPvaUNvS13dvKf666OAm8YTi0+Ca3n1nLEyu49Cy4+dPWpaHFJk9g==",
+            "peer": true
         },
         "node_modules/didyoumean": {
             "version": "1.2.2",
@@ -4491,6 +4497,11 @@
                 "type": "patreon",
                 "url": "https://github.com/sponsors/rawify"
             }
+        },
+        "node_modules/fs-constants": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+            "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="
         },
         "node_modules/fs-extra": {
             "version": "8.1.0",
@@ -6225,68 +6236,158 @@
             }
         },
         "node_modules/puppeteer-core": {
-            "version": "21.6.0",
-            "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-21.6.0.tgz",
-            "integrity": "sha512-1vrzbp2E1JpBwtIIrriWkN+A0afUxkqRuFTC3uASc5ql6iuK9ppOdIU/CPGKwOyB4YFIQ16mRbK0PK19mbXnaQ==",
+            "version": "19.11.1",
+            "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-19.11.1.tgz",
+            "integrity": "sha512-qcuC2Uf0Fwdj9wNtaTZ2OvYRraXpAK+puwwVW8ofOhOgLPZyz1c68tsorfIZyCUOpyBisjr+xByu7BMbEYMepA==",
             "dependencies": {
-                "@puppeteer/browsers": "1.9.0",
-                "chromium-bidi": "0.5.1",
-                "cross-fetch": "4.0.0",
+                "@puppeteer/browsers": "0.5.0",
+                "chromium-bidi": "0.4.7",
+                "cross-fetch": "3.1.5",
                 "debug": "4.3.4",
-                "devtools-protocol": "0.0.1203626",
-                "ws": "8.14.2"
+                "devtools-protocol": "0.0.1107588",
+                "extract-zip": "2.0.1",
+                "https-proxy-agent": "5.0.1",
+                "proxy-from-env": "1.1.0",
+                "tar-fs": "2.1.1",
+                "unbzip2-stream": "1.4.3",
+                "ws": "8.13.0"
             },
             "engines": {
-                "node": ">=16.13.2"
+                "node": ">=14.14.0"
+            },
+            "peerDependencies": {
+                "typescript": ">= 4.7.4"
+            },
+            "peerDependenciesMeta": {
+                "typescript": {
+                    "optional": true
+                }
             }
         },
         "node_modules/puppeteer-core/node_modules/@puppeteer/browsers": {
-            "version": "1.9.0",
-            "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-1.9.0.tgz",
-            "integrity": "sha512-QwguOLy44YBGC8vuPP2nmpX4MUN2FzWbsnvZJtiCzecU3lHmVZkaC1tq6rToi9a200m8RzlVtDyxCS0UIDrxUg==",
+            "version": "0.5.0",
+            "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-0.5.0.tgz",
+            "integrity": "sha512-Uw6oB7VvmPRLE4iKsjuOh8zgDabhNX67dzo8U/BB0f9527qx+4eeUs+korU98OhG5C4ubg7ufBgVi63XYwS6TQ==",
             "dependencies": {
                 "debug": "4.3.4",
                 "extract-zip": "2.0.1",
+                "https-proxy-agent": "5.0.1",
                 "progress": "2.0.3",
-                "proxy-agent": "6.3.1",
-                "tar-fs": "3.0.4",
+                "proxy-from-env": "1.1.0",
+                "tar-fs": "2.1.1",
                 "unbzip2-stream": "1.4.3",
-                "yargs": "17.7.2"
+                "yargs": "17.7.1"
             },
             "bin": {
                 "browsers": "lib/cjs/main-cli.js"
             },
             "engines": {
-                "node": ">=16.3.0"
+                "node": ">=14.1.0"
+            },
+            "peerDependencies": {
+                "typescript": ">= 4.7.4"
+            },
+            "peerDependenciesMeta": {
+                "typescript": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/puppeteer-core/node_modules/agent-base": {
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+            "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+            "dependencies": {
+                "debug": "4"
+            },
+            "engines": {
+                "node": ">= 6.0.0"
             }
         },
         "node_modules/puppeteer-core/node_modules/chromium-bidi": {
-            "version": "0.5.1",
-            "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-0.5.1.tgz",
-            "integrity": "sha512-dcCqOgq9fHKExc2R4JZs/oKbOghWpUNFAJODS8WKRtLhp3avtIH5UDCBrutdqZdh3pARogH8y1ObXm87emwb3g==",
+            "version": "0.4.7",
+            "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-0.4.7.tgz",
+            "integrity": "sha512-6+mJuFXwTMU6I3vYLs6IL8A1DyQTPjCfIL971X0aMPVGRbGnNfl6i6Cl0NMbxi2bRYLGESt9T2ZIMRM5PAEcIQ==",
             "dependencies": {
-                "mitt": "3.0.1",
-                "urlpattern-polyfill": "9.0.0"
+                "mitt": "3.0.0"
             },
             "peerDependencies": {
                 "devtools-protocol": "*"
             }
         },
-        "node_modules/puppeteer-core/node_modules/yargs": {
-            "version": "17.7.2",
-            "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
-            "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+        "node_modules/puppeteer-core/node_modules/cross-fetch": {
+            "version": "3.1.5",
+            "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.5.tgz",
+            "integrity": "sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==",
             "dependencies": {
-                "cliui": "^8.0.1",
-                "escalade": "^3.1.1",
-                "get-caller-file": "^2.0.5",
-                "require-directory": "^2.1.1",
-                "string-width": "^4.2.3",
-                "y18n": "^5.0.5",
-                "yargs-parser": "^21.1.1"
+                "node-fetch": "2.6.7"
+            }
+        },
+        "node_modules/puppeteer-core/node_modules/devtools-protocol": {
+            "version": "0.0.1107588",
+            "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1107588.tgz",
+            "integrity": "sha512-yIR+pG9x65Xko7bErCUSQaDLrO/P1p3JUzEk7JCU4DowPcGHkTGUGQapcfcLc4qj0UaALwZ+cr0riFgiqpixcg=="
+        },
+        "node_modules/puppeteer-core/node_modules/https-proxy-agent": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+            "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+            "dependencies": {
+                "agent-base": "6",
+                "debug": "4"
             },
             "engines": {
-                "node": ">=12"
+                "node": ">= 6"
+            }
+        },
+        "node_modules/puppeteer-core/node_modules/mitt": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.0.tgz",
+            "integrity": "sha512-7dX2/10ITVyqh4aOSVI9gdape+t9l2/8QxHrFmUXu4EEUpdlxl6RudZUPZoc+zuY2hk1j7XxVroIVIan/pD/SQ=="
+        },
+        "node_modules/puppeteer-core/node_modules/node-fetch": {
+            "version": "2.6.7",
+            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+            "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+            "dependencies": {
+                "whatwg-url": "^5.0.0"
+            },
+            "engines": {
+                "node": "4.x || >=6.0.0"
+            },
+            "peerDependencies": {
+                "encoding": "^0.1.0"
+            },
+            "peerDependenciesMeta": {
+                "encoding": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/puppeteer-core/node_modules/tar-fs": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.1.tgz",
+            "integrity": "sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==",
+            "dependencies": {
+                "chownr": "^1.1.1",
+                "mkdirp-classic": "^0.5.2",
+                "pump": "^3.0.0",
+                "tar-stream": "^2.1.4"
+            }
+        },
+        "node_modules/puppeteer-core/node_modules/tar-stream": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+            "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+            "dependencies": {
+                "bl": "^4.0.3",
+                "end-of-stream": "^1.4.1",
+                "fs-constants": "^1.0.0",
+                "inherits": "^2.0.3",
+                "readable-stream": "^3.1.1"
+            },
+            "engines": {
+                "node": ">=6"
             }
         },
         "node_modules/puppeteer/node_modules/devtools-protocol": {
@@ -7883,9 +7984,9 @@
             "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
         },
         "node_modules/ws": {
-            "version": "8.14.2",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-8.14.2.tgz",
-            "integrity": "sha512-wEBG1ftX4jcglPxgFCMJmZ2PLtSbJ2Peg6TmpJFTbe9GZYOQCDPdMYu/Tm0/bGZkw8paZnJY45J4K2PZrLYq8g==",
+            "version": "8.13.0",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-8.13.0.tgz",
+            "integrity": "sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==",
             "engines": {
                 "node": ">=10.0.0"
             },

--- a/package-lock.json
+++ b/package-lock.json
@@ -44,7 +44,7 @@
                 "number-to-words": "^1.2.4",
                 "postcss": "8.4.31",
                 "puppeteer": "^21.3.1",
-                "puppeteer-core": "^19.8.0",
+                "puppeteer-core": "^21.6.0",
                 "react": "18.2.0",
                 "react-day-picker": "^8.8.2",
                 "react-dom": "18.2.0",
@@ -3637,11 +3637,6 @@
                 "node": ">= 6"
             }
         },
-        "node_modules/chownr": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
-            "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="
-        },
         "node_modules/chromium-bidi": {
             "version": "0.4.27",
             "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-0.4.27.tgz",
@@ -4030,8 +4025,7 @@
         "node_modules/devtools-protocol": {
             "version": "0.0.1203626",
             "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1203626.tgz",
-            "integrity": "sha512-nEzHZteIUZfGCZtTiS1fRpC8UZmsfD1SiyPvaUNvS13dvKf666OAm8YTi0+Ca3n1nLEyu49Cy4+dPWpaHFJk9g==",
-            "peer": true
+            "integrity": "sha512-nEzHZteIUZfGCZtTiS1fRpC8UZmsfD1SiyPvaUNvS13dvKf666OAm8YTi0+Ca3n1nLEyu49Cy4+dPWpaHFJk9g=="
         },
         "node_modules/didyoumean": {
             "version": "1.2.2",
@@ -4497,11 +4491,6 @@
                 "type": "patreon",
                 "url": "https://github.com/sponsors/rawify"
             }
-        },
-        "node_modules/fs-constants": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
-            "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="
         },
         "node_modules/fs-extra": {
             "version": "8.1.0",
@@ -6236,158 +6225,68 @@
             }
         },
         "node_modules/puppeteer-core": {
-            "version": "19.11.1",
-            "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-19.11.1.tgz",
-            "integrity": "sha512-qcuC2Uf0Fwdj9wNtaTZ2OvYRraXpAK+puwwVW8ofOhOgLPZyz1c68tsorfIZyCUOpyBisjr+xByu7BMbEYMepA==",
+            "version": "21.6.0",
+            "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-21.6.0.tgz",
+            "integrity": "sha512-1vrzbp2E1JpBwtIIrriWkN+A0afUxkqRuFTC3uASc5ql6iuK9ppOdIU/CPGKwOyB4YFIQ16mRbK0PK19mbXnaQ==",
             "dependencies": {
-                "@puppeteer/browsers": "0.5.0",
-                "chromium-bidi": "0.4.7",
-                "cross-fetch": "3.1.5",
+                "@puppeteer/browsers": "1.9.0",
+                "chromium-bidi": "0.5.1",
+                "cross-fetch": "4.0.0",
                 "debug": "4.3.4",
-                "devtools-protocol": "0.0.1107588",
-                "extract-zip": "2.0.1",
-                "https-proxy-agent": "5.0.1",
-                "proxy-from-env": "1.1.0",
-                "tar-fs": "2.1.1",
-                "unbzip2-stream": "1.4.3",
-                "ws": "8.13.0"
+                "devtools-protocol": "0.0.1203626",
+                "ws": "8.14.2"
             },
             "engines": {
-                "node": ">=14.14.0"
-            },
-            "peerDependencies": {
-                "typescript": ">= 4.7.4"
-            },
-            "peerDependenciesMeta": {
-                "typescript": {
-                    "optional": true
-                }
+                "node": ">=16.13.2"
             }
         },
         "node_modules/puppeteer-core/node_modules/@puppeteer/browsers": {
-            "version": "0.5.0",
-            "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-0.5.0.tgz",
-            "integrity": "sha512-Uw6oB7VvmPRLE4iKsjuOh8zgDabhNX67dzo8U/BB0f9527qx+4eeUs+korU98OhG5C4ubg7ufBgVi63XYwS6TQ==",
+            "version": "1.9.0",
+            "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-1.9.0.tgz",
+            "integrity": "sha512-QwguOLy44YBGC8vuPP2nmpX4MUN2FzWbsnvZJtiCzecU3lHmVZkaC1tq6rToi9a200m8RzlVtDyxCS0UIDrxUg==",
             "dependencies": {
                 "debug": "4.3.4",
                 "extract-zip": "2.0.1",
-                "https-proxy-agent": "5.0.1",
                 "progress": "2.0.3",
-                "proxy-from-env": "1.1.0",
-                "tar-fs": "2.1.1",
+                "proxy-agent": "6.3.1",
+                "tar-fs": "3.0.4",
                 "unbzip2-stream": "1.4.3",
-                "yargs": "17.7.1"
+                "yargs": "17.7.2"
             },
             "bin": {
                 "browsers": "lib/cjs/main-cli.js"
             },
             "engines": {
-                "node": ">=14.1.0"
-            },
-            "peerDependencies": {
-                "typescript": ">= 4.7.4"
-            },
-            "peerDependenciesMeta": {
-                "typescript": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/puppeteer-core/node_modules/agent-base": {
-            "version": "6.0.2",
-            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
-            "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
-            "dependencies": {
-                "debug": "4"
-            },
-            "engines": {
-                "node": ">= 6.0.0"
+                "node": ">=16.3.0"
             }
         },
         "node_modules/puppeteer-core/node_modules/chromium-bidi": {
-            "version": "0.4.7",
-            "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-0.4.7.tgz",
-            "integrity": "sha512-6+mJuFXwTMU6I3vYLs6IL8A1DyQTPjCfIL971X0aMPVGRbGnNfl6i6Cl0NMbxi2bRYLGESt9T2ZIMRM5PAEcIQ==",
+            "version": "0.5.1",
+            "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-0.5.1.tgz",
+            "integrity": "sha512-dcCqOgq9fHKExc2R4JZs/oKbOghWpUNFAJODS8WKRtLhp3avtIH5UDCBrutdqZdh3pARogH8y1ObXm87emwb3g==",
             "dependencies": {
-                "mitt": "3.0.0"
+                "mitt": "3.0.1",
+                "urlpattern-polyfill": "9.0.0"
             },
             "peerDependencies": {
                 "devtools-protocol": "*"
             }
         },
-        "node_modules/puppeteer-core/node_modules/cross-fetch": {
-            "version": "3.1.5",
-            "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.5.tgz",
-            "integrity": "sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==",
+        "node_modules/puppeteer-core/node_modules/yargs": {
+            "version": "17.7.2",
+            "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+            "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
             "dependencies": {
-                "node-fetch": "2.6.7"
-            }
-        },
-        "node_modules/puppeteer-core/node_modules/devtools-protocol": {
-            "version": "0.0.1107588",
-            "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1107588.tgz",
-            "integrity": "sha512-yIR+pG9x65Xko7bErCUSQaDLrO/P1p3JUzEk7JCU4DowPcGHkTGUGQapcfcLc4qj0UaALwZ+cr0riFgiqpixcg=="
-        },
-        "node_modules/puppeteer-core/node_modules/https-proxy-agent": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
-            "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
-            "dependencies": {
-                "agent-base": "6",
-                "debug": "4"
+                "cliui": "^8.0.1",
+                "escalade": "^3.1.1",
+                "get-caller-file": "^2.0.5",
+                "require-directory": "^2.1.1",
+                "string-width": "^4.2.3",
+                "y18n": "^5.0.5",
+                "yargs-parser": "^21.1.1"
             },
             "engines": {
-                "node": ">= 6"
-            }
-        },
-        "node_modules/puppeteer-core/node_modules/mitt": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.0.tgz",
-            "integrity": "sha512-7dX2/10ITVyqh4aOSVI9gdape+t9l2/8QxHrFmUXu4EEUpdlxl6RudZUPZoc+zuY2hk1j7XxVroIVIan/pD/SQ=="
-        },
-        "node_modules/puppeteer-core/node_modules/node-fetch": {
-            "version": "2.6.7",
-            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
-            "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
-            "dependencies": {
-                "whatwg-url": "^5.0.0"
-            },
-            "engines": {
-                "node": "4.x || >=6.0.0"
-            },
-            "peerDependencies": {
-                "encoding": "^0.1.0"
-            },
-            "peerDependenciesMeta": {
-                "encoding": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/puppeteer-core/node_modules/tar-fs": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.1.tgz",
-            "integrity": "sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==",
-            "dependencies": {
-                "chownr": "^1.1.1",
-                "mkdirp-classic": "^0.5.2",
-                "pump": "^3.0.0",
-                "tar-stream": "^2.1.4"
-            }
-        },
-        "node_modules/puppeteer-core/node_modules/tar-stream": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
-            "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
-            "dependencies": {
-                "bl": "^4.0.3",
-                "end-of-stream": "^1.4.1",
-                "fs-constants": "^1.0.0",
-                "inherits": "^2.0.3",
-                "readable-stream": "^3.1.1"
-            },
-            "engines": {
-                "node": ">=6"
+                "node": ">=12"
             }
         },
         "node_modules/puppeteer/node_modules/devtools-protocol": {
@@ -7984,9 +7883,9 @@
             "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
         },
         "node_modules/ws": {
-            "version": "8.13.0",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-8.13.0.tgz",
-            "integrity": "sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==",
+            "version": "8.14.2",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-8.14.2.tgz",
+            "integrity": "sha512-wEBG1ftX4jcglPxgFCMJmZ2PLtSbJ2Peg6TmpJFTbe9GZYOQCDPdMYu/Tm0/bGZkw8paZnJY45J4K2PZrLYq8g==",
             "engines": {
                 "node": ">=10.0.0"
             },

--- a/package.json
+++ b/package.json
@@ -44,8 +44,8 @@
         "nodemailer": "^6.9.7",
         "number-to-words": "^1.2.4",
         "postcss": "8.4.31",
-        "puppeteer": "^21.3.1",
         "puppeteer-core": "^21.5.0",
+        "@sparticuz/chromium": "^119.0.0",
         "react": "18.2.0",
         "react-day-picker": "^8.8.2",
         "react-dom": "18.2.0",
@@ -64,7 +64,7 @@
         "zod": "^3.22.2"
     },
     "devDependencies": {
-        "@sparticuz/chromium": "^119.0.0",
+        "puppeteer": "^21.3.1",
         "@types/nodemailer": "^6.4.14",
         "@types/number-to-words": "^1.2.1",
         "@types/react": "^18.2.22",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
         "number-to-words": "^1.2.4",
         "postcss": "8.4.31",
         "puppeteer": "^21.3.1",
-        "puppeteer-core": "^21.6.0",
+        "puppeteer-core": "^19.8.0",
         "react": "18.2.0",
         "react-day-picker": "^8.8.2",
         "react-dom": "18.2.0",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
         "number-to-words": "^1.2.4",
         "postcss": "8.4.31",
         "puppeteer": "^21.3.1",
-        "puppeteer-core": "^19.8.0",
+        "puppeteer-core": "^21.6.0",
         "react": "18.2.0",
         "react-day-picker": "^8.8.2",
         "react-dom": "18.2.0",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
         "number-to-words": "^1.2.4",
         "postcss": "8.4.31",
         "puppeteer": "^21.3.1",
-        "puppeteer-core": "^10.4.0",
+        "puppeteer-core": "^19.8.0",
         "react": "18.2.0",
         "react-day-picker": "^8.8.2",
         "react-dom": "18.2.0",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
         "number-to-words": "^1.2.4",
         "postcss": "8.4.31",
         "puppeteer": "^21.3.1",
-        "puppeteer-core": "^19.8.0",
+        "puppeteer-core": "^21.5.0",
         "react": "18.2.0",
         "react-day-picker": "^8.8.2",
         "react-dom": "18.2.0",

--- a/services/invoice/server/generatePdfService.ts
+++ b/services/invoice/server/generatePdfService.ts
@@ -39,7 +39,7 @@ export async function generatePdfService(req: NextRequest) {
 
         // Launch the browser in production or development mode depending on the environment
         if (ENV === "production") {
-            const puppeteer = await import("puppeteer-core");
+            const puppeteer = (await import("puppeteer-core")) as any;
             browser = await puppeteer.launch({
                 args: chromium.args,
                 defaultViewport: chromium.defaultViewport,

--- a/services/invoice/server/generatePdfService.ts
+++ b/services/invoice/server/generatePdfService.ts
@@ -44,7 +44,7 @@ export async function generatePdfService(req: NextRequest) {
                 args: chromium.args,
                 defaultViewport: chromium.defaultViewport,
                 executablePath: await chromium.executablePath(
-                    `https://github.com/Sparticuz/chromium/releases/download/v116.0.0/chromium-v116.0.0-pack.tar`
+                    `https://github.com/Sparticuz/chromium/releases/download/v119.0.0/chromium-v119.0.0-pack.tar`
                 ),
                 headless:
                     chromium.headless === "new" ? true : chromium.headless,

--- a/services/invoice/server/generatePdfService.ts
+++ b/services/invoice/server/generatePdfService.ts
@@ -39,7 +39,7 @@ export async function generatePdfService(req: NextRequest) {
 
         // Launch the browser in production or development mode depending on the environment
         if (ENV === "production") {
-            const puppeteer = (await import("puppeteer-core")) as any;
+            const puppeteer = await import("puppeteer-core");
             browser = await puppeteer.launch({
                 args: chromium.args,
                 defaultViewport: chromium.defaultViewport,


### PR DESCRIPTION
### Changes

- Updated `puppeteer-core` version to ^21.5.0. This fixes security issues related to the old puppeteer-core version
- Moved `puppeteer` package to devDependencies
- Moved `@sparticuz/chromium` library to dependencies
- Marked `puppeteer-core` as external in the next config

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced an experimental feature to improve server-side rendering capabilities.

- **Bug Fixes**
  - Updated the PDF generation service with the latest Chromium package for enhanced stability and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->